### PR TITLE
replace MessageCircle with FaWhatsapp in Header component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "lucide-react": "^0.483.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-icons": "^5.5.0",
         "react-router-dom": "^6.22.3"
       },
       "devDependencies": {
@@ -6793,6 +6794,14 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
+      "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-refresh": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "lucide-react": "^0.483.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-icons": "^5.5.0",
     "react-router-dom": "^6.22.3"
   },
   "devDependencies": {

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { useNavigate, useLocation } from "react-router-dom";
-import { ArrowLeft, MessageCircle } from "lucide-react";
+import { ArrowLeft } from "lucide-react";
+import { FaWhatsapp } from "react-icons/fa";
 
 interface HeaderProps {
   title: string;
@@ -41,8 +42,9 @@ const Header: React.FC<HeaderProps> = ({ title, showBack = false }) => {
           className="relative"
           aria-label="Buka Chat"
         >
-          <MessageCircle size={24} />
-        </button>
+<div className="bg-green-500 rounded-full p-1.5">
+            <FaWhatsapp size={28} className="text-white" />
+          </div>        </button>
       </div>
     </header>
   );


### PR DESCRIPTION
This pull request introduces a new dependency (`react-icons`) and updates the `Header` component to replace the `MessageCircle` icon from `lucide-react` with the `FaWhatsapp` icon from `react-icons`. These changes enhance the visual design and functionality of the `Header` component.

### Dependency Updates:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R20): Added `react-icons` version `^5.5.0` as a new dependency.

### Component Updates:
* [`src/components/Header.tsx`](diffhunk://#diff-940a5ae8f5fb47c5c177e82e62f63d31a84d367613d20e22294c818fd4bc562fL3-R4): Replaced the `MessageCircle` icon from `lucide-react` with the `FaWhatsapp` icon from `react-icons`. This includes importing `FaWhatsapp` and updating the JSX to use a styled `FaWhatsapp` icon wrapped in a green, rounded background. [[1]](diffhunk://#diff-940a5ae8f5fb47c5c177e82e62f63d31a84d367613d20e22294c818fd4bc562fL3-R4) [[2]](diffhunk://#diff-940a5ae8f5fb47c5c177e82e62f63d31a84d367613d20e22294c818fd4bc562fL44-R47)